### PR TITLE
182 overwrite support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-    - "2.6"
     - "2.7"
     - "3.3"
     - "3.4"
@@ -20,7 +19,6 @@ addons:
 
 install:
     - "pip install 'requests>2'"
-    - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install unittest2; fi
     - "pip install ."
 
 script:

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Features
 Requirements
 ============
 
-* Python 2.6 - 3.5
+* Python 2.7 - 3.5
 * Requests 2.0+
 * **Optional** - ``simplejson``
 

--- a/pysolr.py
+++ b/pysolr.py
@@ -317,6 +317,9 @@ class Solr(object):
         self.session.stream = False
         self.results_cls = results_cls
 
+    def __del__(self):
+        self.session.close()
+
     def _get_log(self):
         return LOG
 

--- a/pysolr.py
+++ b/pysolr.py
@@ -148,7 +148,7 @@ def unescape_html(text):
                 text = unicode_char(htmlentities.name2codepoint[text[1:-1]])
             except KeyError:
                 pass
-        return text # leave as is
+        return text  # leave as is
     return re.sub("&#?\w+;", fixup, text)
 
 
@@ -186,7 +186,8 @@ def is_valid_xml_char_ordinal(i):
 
     Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
     """
-    return ( # conditions ordered by presumed frequency
+    # conditions ordered by presumed frequency
+    return (
         0x20 <= i <= 0xD7FF
         or i in (0x9, 0xA, 0xD)
         or 0xE000 <= i <= 0xFFFD
@@ -545,6 +546,8 @@ class Solr(object):
                 if reason is None:
                     full_html = ElementTree.tostring(dom_tree)
             except SyntaxError as err:
+                LOG.warning('Unable to extract error message from invalid XML: %s', err,
+                            extra={'data': {'response': response}})
                 full_html = "%s" % response
 
         full_html = force_unicode(full_html)
@@ -616,7 +619,7 @@ class Solr(object):
             if isinstance(value, basestring):
                 is_string = True
 
-        if is_string == True:
+        if is_string:
             possible_datetime = DATETIME_REGEX.search(value)
 
             if possible_datetime:
@@ -1084,36 +1087,37 @@ class SolrCoreAdmin(object):
 # Using two-tuples to preserve order.
 REPLACEMENTS = (
     # Nuke nasty control characters.
-    (b'\x00', b''), # Start of heading
-    (b'\x01', b''), # Start of heading
-    (b'\x02', b''), # Start of text
-    (b'\x03', b''), # End of text
-    (b'\x04', b''), # End of transmission
-    (b'\x05', b''), # Enquiry
-    (b'\x06', b''), # Acknowledge
-    (b'\x07', b''), # Ring terminal bell
-    (b'\x08', b''), # Backspace
-    (b'\x0b', b''), # Vertical tab
-    (b'\x0c', b''), # Form feed
-    (b'\x0e', b''), # Shift out
-    (b'\x0f', b''), # Shift in
-    (b'\x10', b''), # Data link escape
-    (b'\x11', b''), # Device control 1
-    (b'\x12', b''), # Device control 2
-    (b'\x13', b''), # Device control 3
-    (b'\x14', b''), # Device control 4
-    (b'\x15', b''), # Negative acknowledge
-    (b'\x16', b''), # Synchronous idle
-    (b'\x17', b''), # End of transmission block
-    (b'\x18', b''), # Cancel
-    (b'\x19', b''), # End of medium
-    (b'\x1a', b''), # Substitute character
-    (b'\x1b', b''), # Escape
-    (b'\x1c', b''), # File separator
-    (b'\x1d', b''), # Group separator
-    (b'\x1e', b''), # Record separator
-    (b'\x1f', b''), # Unit separator
+    (b'\x00', b''),  # Start of heading
+    (b'\x01', b''),  # Start of heading
+    (b'\x02', b''),  # Start of text
+    (b'\x03', b''),  # End of text
+    (b'\x04', b''),  # End of transmission
+    (b'\x05', b''),  # Enquiry
+    (b'\x06', b''),  # Acknowledge
+    (b'\x07', b''),  # Ring terminal bell
+    (b'\x08', b''),  # Backspace
+    (b'\x0b', b''),  # Vertical tab
+    (b'\x0c', b''),  # Form feed
+    (b'\x0e', b''),  # Shift out
+    (b'\x0f', b''),  # Shift in
+    (b'\x10', b''),  # Data link escape
+    (b'\x11', b''),  # Device control 1
+    (b'\x12', b''),  # Device control 2
+    (b'\x13', b''),  # Device control 3
+    (b'\x14', b''),  # Device control 4
+    (b'\x15', b''),  # Negative acknowledge
+    (b'\x16', b''),  # Synchronous idle
+    (b'\x17', b''),  # End of transmission block
+    (b'\x18', b''),  # Cancel
+    (b'\x19', b''),  # End of medium
+    (b'\x1a', b''),  # Substitute character
+    (b'\x1b', b''),  # Escape
+    (b'\x1c', b''),  # File separator
+    (b'\x1d', b''),  # Group separator
+    (b'\x1e', b''),  # Record separator
+    (b'\x1f', b''),  # Unit separator
 )
+
 
 def sanitize(data):
     fixed_string = force_bytes(data)

--- a/pysolr.py
+++ b/pysolr.py
@@ -187,12 +187,10 @@ def is_valid_xml_char_ordinal(i):
     Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
     """
     # conditions ordered by presumed frequency
-    return (
-        0x20 <= i <= 0xD7FF
-        or i in (0x9, 0xA, 0xD)
-        or 0xE000 <= i <= 0xFFFD
-        or 0x10000 <= i <= 0x10FFFF
-        )
+    return (0x20 <= i <= 0xD7FF
+            or i in (0x9, 0xA, 0xD)
+            or 0xE000 <= i <= 0xFFFD
+            or 0x10000 <= i <= 0x10FFFF)
 
 
 def clean_xml_string(s):

--- a/run-tests.py
+++ b/run-tests.py
@@ -39,13 +39,8 @@ def start_solr():
 def main():
     solr_proc = start_solr()
 
-    if sys.version_info >= (3, 3) or sys.version_info >= (2, 7):
-        cmd = ['python', '-m', 'unittest', 'tests']
-    else:
-        cmd = ['unit2', 'discover', '-s', 'tests', '-p', '[a-z]*.py']
-
     try:
-        subprocess.check_call(cmd)
+        subprocess.check_call(['python', '-m', 'unittest', 'tests'])
     finally:
         solr_proc.terminate()
         solr_proc.wait()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,12 @@
 [wheel]
 universal = 1
+
+[pep8]
+ignore = W503
+
+[isort]
+combine_as_imports = true
+default_section = THIRDPARTY
+known_first_party = pysolr
+multi_line_output = 0
+not_skip = __init__.py

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,2 @@
-from .client import *
 from .admin import *
+from .client import *

--- a/tests/admin.py
+++ b/tests/admin.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-from pysolr import SolrCoreAdmin, json
+from pysolr import SolrCoreAdmin
 
 try:
     import unittest2 as unittest

--- a/tests/admin.py
+++ b/tests/admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from pysolr import SolrCoreAdmin, json
 

--- a/tests/client.py
+++ b/tests/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import datetime
 import unittest

--- a/tests/client.py
+++ b/tests/client.py
@@ -6,15 +6,14 @@ import unittest
 from io import StringIO
 from xml.etree import ElementTree
 
-from pysolr import (IS_PY3, Results, Solr, SolrError, clean_xml_string,
-                    force_bytes, force_unicode, json, safe_urlencode, sanitize,
+from pysolr import (Results, Solr, SolrError, clean_xml_string, force_bytes,
+                    force_unicode, json, safe_urlencode, sanitize,
                     unescape_html)
 
 try:
     from urllib.parse import unquote_plus
 except ImportError:
     from urllib import unquote_plus
-
 
 
 class UtilsTestCase(unittest.TestCase):
@@ -241,11 +240,10 @@ class SolrTestCase(unittest.TestCase):
         self.assertEqual(len(resp_data['responseHeader']['params']['q']), 3 * 1024)
 
         # Test Deep Pagination CursorMark
-        resp_body = self.solr._select({'q': '*', 'cursorMark':'*', 'sort':'id desc', 'start':0, 'rows': 2})
+        resp_body = self.solr._select({'q': '*', 'cursorMark': '*', 'sort': 'id desc', 'start': 0, 'rows': 2})
         resp_data = json.loads(resp_body)
         self.assertEqual(len(resp_data['response']['docs']), 2)
         self.assertIn('nextCursorMark', resp_data)
-
 
     def test__mlt(self):
         resp_body = self.solr._mlt({'q': 'id:doc_1', 'mlt.fl': 'title'})
@@ -332,7 +330,6 @@ class SolrTestCase(unittest.TestCase):
         reason, full_html = self.solr._scrape_response({'server': 'coyote'}, bogus_xml)
         self.assertEqual(reason, None)
         self.assertEqual(full_html, bogus_xml.replace("\n", ""))
-
 
     def test__from_python(self):
         self.assertEqual(self.solr._from_python(datetime.date(2013, 1, 18)), '2013-01-18T00:00:00Z')
@@ -466,7 +463,7 @@ class SolrTestCase(unittest.TestCase):
         self.assertEqual(len(originalDocs), 3)
         updateList = []
         for i, doc in enumerate(originalDocs):
-            updateList.append( {'id': doc['id'], 'popularity': 5} )
+            updateList.append({'id': doc['id'], 'popularity': 5})
         self.solr.add(updateList, fieldUpdates={'popularity': 'inc'})
 
         updatedDocs = self.solr.search('doc')
@@ -474,7 +471,9 @@ class SolrTestCase(unittest.TestCase):
         for i, (originalDoc, updatedDoc) in enumerate(zip(originalDocs, updatedDocs)):
             self.assertEqual(len(updatedDoc.keys()), len(originalDoc.keys()))
             self.assertEqual(updatedDoc['popularity'], originalDoc['popularity'] + 5)
-            self.assertEqual(True, all(updatedDoc[k] == originalDoc[k] for k in updatedDoc.keys() if not k in ['_version_', 'popularity']))
+            # TODO: change this to use assertSetEqual:
+            self.assertEqual(True, all(updatedDoc[k] == originalDoc[k] for k in updatedDoc.keys()
+                                       if k not in ['_version_', 'popularity']))
 
         self.solr.add([
             {
@@ -493,7 +492,7 @@ class SolrTestCase(unittest.TestCase):
         self.assertEqual(len(originalDocs), 2)
         updateList = []
         for i, doc in enumerate(originalDocs):
-            updateList.append( {'id': doc['id'], 'word_ss': ['epsilon', 'gamma']} )
+            updateList.append({'id': doc['id'], 'word_ss': ['epsilon', 'gamma']})
         self.solr.add(updateList, fieldUpdates={'word_ss': 'add'})
 
         updatedDocs = self.solr.search('multivalued')
@@ -501,7 +500,9 @@ class SolrTestCase(unittest.TestCase):
         for i, (originalDoc, updatedDoc) in enumerate(zip(originalDocs, updatedDocs)):
             self.assertEqual(len(updatedDoc.keys()), len(originalDoc.keys()))
             self.assertEqual(updatedDoc['word_ss'], originalDoc['word_ss'] + ['epsilon', 'gamma'])
-            self.assertEqual(True, all(updatedDoc[k] == originalDoc[k] for k in updatedDoc.keys() if not k in ['_version_', 'word_ss']))
+            # TODO: change this to use assertSetEqual:
+            self.assertEqual(True, all(updatedDoc[k] == originalDoc[k] for k in updatedDoc.keys()
+                                       if k not in ['_version_', 'word_ss']))
 
     def test_delete(self):
         self.assertEqual(len(self.solr.search('doc')), 3)

--- a/tests/client.py
+++ b/tests/client.py
@@ -2,26 +2,19 @@
 from __future__ import unicode_literals
 
 import datetime
-import sys
+import unittest
+from io import StringIO
+from xml.etree import ElementTree
 
-from pysolr import (Solr, Results, SolrError, unescape_html, safe_urlencode,
-                    force_unicode, force_bytes, sanitize, json, ET, IS_PY3,
-                    clean_xml_string)
-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+from pysolr import (IS_PY3, Results, Solr, SolrError, clean_xml_string,
+                    force_bytes, force_unicode, json, safe_urlencode, sanitize,
+                    unescape_html)
 
 try:
     from urllib.parse import unquote_plus
 except ImportError:
     from urllib import unquote_plus
 
-if IS_PY3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
 
 
 class UtilsTestCase(unittest.TestCase):
@@ -317,7 +310,6 @@ class SolrTestCase(unittest.TestCase):
         resp_2 = self.solr._scrape_response({'server': 'crapzilla'}, '<html><head><title>Wow. Seriously weird.</title></head><body><pre>Something is broke.</pre></body></html>')
         self.assertEqual(resp_2, ('Wow. Seriously weird.', u''))
 
-    @unittest.skipIf(sys.version_info < (2, 7), reason=u'Python 2.6 lacks the ElementTree 1.3 interface required for Solr XML error message parsing')
     def test__scrape_response_coyote_xml(self):
         resp_3 = self.solr._scrape_response({'server': 'coyote'}, '<?xml version="1.0"?>\n<response>\n<lst name="responseHeader"><int name="status">400</int><int name="QTime">0</int></lst><lst name="error"><str name="msg">Invalid Date String:\'2015-03-23 10:43:33\'</str><int name="code">400</int></lst>\n</response>\n')
         self.assertEqual(resp_3, ("Invalid Date String:'2015-03-23 10:43:33'", "Invalid Date String:'2015-03-23 10:43:33'"))
@@ -433,7 +425,7 @@ class SolrTestCase(unittest.TestCase):
             'price': 12.59,
             'popularity': 10,
         }
-        doc_xml = force_unicode(ET.tostring(self.solr._build_doc(doc), encoding='utf-8'))
+        doc_xml = force_unicode(ElementTree.tostring(self.solr._build_doc(doc), encoding='utf-8'))
         self.assertTrue('<field name="title">Example doc ☃ 1</field>' in doc_xml)
         self.assertTrue('<field name="id">doc_1</field>' in doc_xml)
         self.assertEqual(len(doc_xml), 152)


### PR DESCRIPTION
This PR fixes the `run-tests.py:554` assert(len(self.solr.search())==2) failure by explicitly checking for id:doc_overwrite_1. Searching for just doc_overwrite_1 returns no hits.

run-tests.py returns:

$ ./run-tests.py 
Waiting 10 seconds for Solr to start (retry #1)
Waiting 10 seconds for Solr to start (retry #2)
## ..............................................

Ran 46 tests in 32.040s

OK
